### PR TITLE
add collect_only argument to catbox.run

### DIFF
--- a/src/catbox.c
+++ b/src/catbox.c
@@ -48,7 +48,7 @@ catbox_run(PyObject *self, PyObject *args, PyObject *kwargs)
 		"function",
 		"writable_paths",
 		"network",
-                "collect_only",
+		"collect_only",
 		"logger",
 		"args",
 		NULL

--- a/src/catbox.c
+++ b/src/catbox.c
@@ -48,6 +48,7 @@ catbox_run(PyObject *self, PyObject *args, PyObject *kwargs)
 		"function",
 		"writable_paths",
 		"network",
+                "collect_only",
 		"logger",
 		"args",
 		NULL
@@ -55,14 +56,15 @@ catbox_run(PyObject *self, PyObject *args, PyObject *kwargs)
 	PyObject *ret;
 	PyObject *paths = NULL;
 	PyObject *net = NULL;
+	PyObject *collect_only = NULL;
 	struct trace_context ctx;
 	struct traced_child *child, *temp;
 	int i;
 
 	memset(&ctx, 0, sizeof(struct trace_context));
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOO",
-		kwlist, &ctx.func, &paths, &net, &ctx.logger, &ctx.func_args))
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOO",
+		kwlist, &ctx.func, &paths, &net, &collect_only, &ctx.logger, &ctx.func_args))
 			return NULL;
 
 	if (PyCallable_Check(ctx.func) == 0) {
@@ -84,6 +86,11 @@ catbox_run(PyObject *self, PyObject *args, PyObject *kwargs)
 		ctx.network_allowed = 1;
 	else
 		ctx.network_allowed = 0;
+
+	if (collect_only && PyObject_IsTrue(collect_only))
+		ctx.collect_only = 1;
+	else
+		ctx.collect_only = 0;
 
 	catbox_retval_init(&ctx);
 

--- a/src/catbox.h
+++ b/src/catbox.h
@@ -49,6 +49,8 @@ struct trace_context {
 	char **pathlist;
 	/* is network connection allowed */
 	int network_allowed;
+	/* collect violations only or block syscall violations */
+	int collect_only;
 	/* per process data table, hashed by process id */
 	unsigned int nr_children;
 	struct traced_child *children[PID_TABLE_SIZE];

--- a/src/syscall.c
+++ b/src/syscall.c
@@ -373,9 +373,11 @@ catbox_syscall_handle(struct trace_context *ctx, struct traced_child *kid)
 		if (ret != 0) {
 			kid->error_code = ret;
 			kid->orig_call = regs.REG_CALL;
-			// prevent the call by giving an invalid call number
-			regs.REG_CALL = 0xbadca11;
-			ptrace(PTRACE_SETREGS, pid, 0, &regs);
+			if (!ctx->collect_only) {
+				// prevent the call by giving an invalid call number
+				regs.REG_CALL = 0xbadca11;
+				ptrace(PTRACE_SETREGS, pid, 0, &regs);
+			}
 		}
 		kid->in_syscall = 1;
 	}


### PR DESCRIPTION
Collects all sandbox violations instead of aborting at first violation.
